### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
## what

- Create dependabot.yml

## why

- help keep dependencies up to date
- after merging, it needs to be enabled on this page https://github.com/benkehoe/aws-whoami-golang/settings/security_analysis
- then it will show a job under dependabot tab here https://github.com/benkehoe/aws-whoami-golang/network/updates

## references

- https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates
- See prs show up in my personal fork https://github.com/nitrocode/aws-whoami-golang/pulls
